### PR TITLE
Hide stderr of SCM programs

### DIFF
--- a/rst/linker.py
+++ b/rst/linker.py
@@ -113,7 +113,8 @@ class SCMTimestamp(Repl):
         )
         cmd = commands[scm]
         try:
-            ts = subprocess.check_output(cmd).decode('utf-8').strip()
+            with open(os.devnull, 'w') as devnull:
+                ts = subprocess.check_output(cmd, stderr=devnull).decode('utf-8').strip()
             assert ts
             ts = dateutil.parser.parse(ts)
         except Exception:


### PR DESCRIPTION
Without this, doc builds from releases look very messy with a lot of `fatal: Not a git repository (or any of the parent directories): .git` lines.
I couldn't use `subprocess.DEVNULL`as it appeared in Python 3.3.
