### PR TITLE
Set fixed locale in tests

### DIFF
--- a/test_all.py
+++ b/test_all.py
@@ -1,14 +1,19 @@
 import textwrap
 import subprocess
+import locale
 
 from path import Path
 import pytest
 
 import rst.linker
 
-import locale
 
-locale.setlocale(locale.LC_ALL, 'C')
+@pytest.fixture(scope='session', autouse=True)
+def stable_locale():
+    """
+    Fix locale to avoid failed tests under other locales.
+    """
+    locale.setlocale(locale.LC_ALL, 'C')
 
 
 @pytest.fixture

--- a/test_all.py
+++ b/test_all.py
@@ -6,6 +6,10 @@ import pytest
 
 import rst.linker
 
+import locale
+
+locale.setlocale(locale.LC_ALL, 'C')
+
 
 @pytest.fixture
 def linker_defn():


### PR DESCRIPTION
Test used local names of months, causing a fail.

To reproduce original issue, run `LC_TIME=ja_JP.UTF-8 pytest` on branch main. Fails with
```
>       assert "Released 24-Feb" in result
E       AssertionError: assert 'Released 24-Feb' in '\n\n1.0\n---\n\nCopyright 2015\nReleased 24- 2月\n\nSome details\n'

test_all.py:115: AssertionError
```

Does not happen anymore with this fix.

An alternative would be to only set the locale in the specific test or only set `LC_TIME`, but I believe this creates more stable testing environment overall.